### PR TITLE
remove temporary dotnet sockets

### DIFF
--- a/examples/dotnet/build.earth
+++ b/examples/dotnet/build.earth
@@ -3,7 +3,7 @@ WORKDIR /dotnet-example
 
 build:
     COPY src src
-    RUN dotnet publish src/HelloEarthly -o publish
+    RUN dotnet publish src/HelloEarthly -o publish && find /tmp -type s | xargs rm
     SAVE ARTIFACT publish AS LOCAL publish
 
 docker:


### PR DESCRIPTION
After dotnet publish runs, it produces some sockets under /tmp which
causes earthly to return an underlying buildkit error stating
"archive/tar: sockets not supported".